### PR TITLE
Use the Form, Luke!

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nuffshell",
+  "name": "nuffshell-frontend",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -17669,6 +17669,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "usetheform": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/usetheform/-/usetheform-3.0.0.tgz",
+      "integrity": "sha512-+ZnJin0Uhqb1qFYBiMr3sjc64HeFtHqdzN6HFQlTz3DsEc786vzkwmiAPPKXw4v4ZACGgRZ5gaYV0dhFNrAG6Q=="
     },
     "util": {
       "version": "0.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17671,9 +17671,9 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "usetheform": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/usetheform/-/usetheform-3.0.0.tgz",
-      "integrity": "sha512-+ZnJin0Uhqb1qFYBiMr3sjc64HeFtHqdzN6HFQlTz3DsEc786vzkwmiAPPKXw4v4ZACGgRZ5gaYV0dhFNrAG6Q=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/usetheform/-/usetheform-3.1.0.tgz",
+      "integrity": "sha512-SZDcnvzzqc1VYYp/HPYpVQ6m+fpBxBE6z82LrDITnquTCJRAgnFJHpk8kJJBQ/SU1Z5OFXO9smFRqqFvArqMVg=="
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
+    "usetheform": "^3.0.0",
     "web-vitals": "^0.2.4",
     "zustand": "^3.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
-    "usetheform": "^3.0.0",
+    "usetheform": "^3.1.0",
     "web-vitals": "^0.2.4",
     "zustand": "^3.2.0"
   },

--- a/src/pages/logIn/LogInPage.tsx
+++ b/src/pages/logIn/LogInPage.tsx
@@ -6,14 +6,14 @@ import {
   TextInput,
   ValidationError,
 } from "../../ui";
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import cx from "classnames";
 import { useAuthentication } from "../../features/authentication";
 import Form, { useValidation } from "usetheform";
 import {
-  validateRequiredPassword,
-  validateRequiredEmail,
   validateEmail,
+  validateRequiredEmail,
+  validateRequiredPassword,
 } from "../utils/validation";
 
 interface FormState {
@@ -27,7 +27,6 @@ const initialFormState: FormState = {
 };
 
 export default function LogInPage() {
-  const [formState, setFormState] = useState(initialFormState);
   const [emailStatus, emailValidation] = useValidation([
     validateRequiredEmail,
     validateEmail,
@@ -35,10 +34,6 @@ export default function LogInPage() {
   const [passwordStatus, passwordValidation] = useValidation([
     validateRequiredPassword,
   ]);
-  const updateFormState = useCallback(
-    (nextFormState) => setFormState(nextFormState),
-    []
-  );
   const { isLoggedIn } = useAuthentication();
   const [status, setStatus] = useState("new");
 
@@ -48,10 +43,8 @@ export default function LogInPage() {
     } catch (error) {
       switch (error.code) {
         case "auth/user-not-found":
-          setStatus("error/user-not-found");
-          break;
         case "auth/wrong-password":
-          setStatus("error/wrong-password");
+          setStatus("error/bad-credentials");
           break;
         default:
           setStatus("error/unknown-cause");
@@ -69,13 +62,7 @@ export default function LogInPage() {
         {status === "success" && <>Success!</>}
       </MainHeadline>
       {status === "new" && !isLoggedIn && (
-        <Form
-          onSubmit={handleSubmit}
-          onReset={updateFormState}
-          onInit={updateFormState}
-          onChange={updateFormState}
-          initialState={initialFormState}
-        >
+        <Form onSubmit={handleSubmit} initialState={initialFormState}>
           <Box
             className={cx(
               "grid",
@@ -127,14 +114,8 @@ export default function LogInPage() {
         </Form>
       )}
       {status === "new" && isLoggedIn && <p>You are already logged in.</p>}
-      {status === "error/user-not-found" && (
-        <p>
-          Sorry, there is no Nuffshell user with email address{" "}
-          <em>{formState.email}</em>.
-        </p>
-      )}
-      {status === "error/wrong-password" && (
-        <p>Sorry, that password is incorrect.</p>
+      {status === "error/bad-credentials" && (
+        <p>Sorry, email or password are incorrect.</p>
       )}
       {status === "error/unknown-cause" && (
         <p>

--- a/src/pages/logIn/LogInPage.tsx
+++ b/src/pages/logIn/LogInPage.tsx
@@ -49,7 +49,7 @@ export default function LogInPage() {
         default:
           setStatus("error/unknown-cause");
       }
-      return;
+      throw error;
     }
     setStatus("success");
   }

--- a/src/pages/logIn/LogInPage.tsx
+++ b/src/pages/logIn/LogInPage.tsx
@@ -9,7 +9,7 @@ import {
 import React, { useState } from "react";
 import cx from "classnames";
 import { useAuthentication } from "../../features/authentication";
-import Form, { useValidation } from "usetheform";
+import { Form, useValidation } from "usetheform";
 import {
   validateEmail,
   validateRequiredEmail,

--- a/src/pages/signUp/SignUpPage.tsx
+++ b/src/pages/signUp/SignUpPage.tsx
@@ -59,7 +59,7 @@ export default function SignUpPage() {
         default:
           setStatus("error/unknown-cause");
       }
-      return;
+      throw error;
     }
     setStatus("success");
   }

--- a/src/pages/signUp/SignUpPage.tsx
+++ b/src/pages/signUp/SignUpPage.tsx
@@ -6,16 +6,16 @@ import {
   TextInput,
   ValidationError,
 } from "../../ui";
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import cx from "classnames";
 import { useAuthentication } from "../../features/authentication";
 import Form, { Collection, useValidation } from "usetheform";
 import {
+  PasswordState,
   validateEmail,
+  validatePasswords,
   validateRequiredEmail,
   validateRequiredPasswords,
-  validatePasswords,
-  PasswordState,
 } from "../utils/validation";
 
 interface FormState {
@@ -32,7 +32,6 @@ const initialFormState: FormState = {
 };
 
 export default function SignUpPage() {
-  const [, setFormState] = useState(initialFormState);
   const [emailStatus, emailValidation] = useValidation([
     validateRequiredEmail,
     validateEmail,
@@ -41,10 +40,6 @@ export default function SignUpPage() {
     validateRequiredPasswords,
     validatePasswords,
   ]);
-  const updateFormState = useCallback(
-    (nextFormState) => setFormState(nextFormState),
-    []
-  );
   const { isLoggedIn } = useAuthentication();
   const [status, setStatus] = useState("new");
 
@@ -77,13 +72,7 @@ export default function SignUpPage() {
         {status === "success" && <>Success!</>}
       </MainHeadline>
       {status === "new" && !isLoggedIn && (
-        <Form
-          onSubmit={handleSubmit}
-          onReset={updateFormState}
-          onInit={updateFormState}
-          onChange={updateFormState}
-          initialState={initialFormState}
-        >
+        <Form onSubmit={handleSubmit} initialState={initialFormState}>
           <Box
             className={cx(
               "grid",

--- a/src/pages/signUp/SignUpPage.tsx
+++ b/src/pages/signUp/SignUpPage.tsx
@@ -36,7 +36,7 @@ export default function SignUpPage() {
     validateRequiredEmail,
     validateEmail,
   ]);
-  const [passwordStatus, passwordValidation] = useValidation([
+  const [passwordsStatus, passwordsValidation] = useValidation([
     validateRequiredPasswords,
     validatePasswords,
   ]);
@@ -100,9 +100,9 @@ export default function SignUpPage() {
               validation={emailValidation}
               maxLength={200}
             />
-            {passwordStatus.error && (
+            {passwordsStatus.error && (
               <ValidationError className={cx("col-span-3")}>
-                {passwordStatus.error}
+                {passwordsStatus.error}
               </ValidationError>
             )}
             <label
@@ -111,7 +111,7 @@ export default function SignUpPage() {
             >
               Choose a password:
             </label>
-            <Collection name="passwords" object {...passwordValidation}>
+            <Collection name="passwords" object {...passwordsValidation}>
               <TextInput
                 id="password"
                 className={cx("col-span-2")}

--- a/src/pages/signUp/SignUpPage.tsx
+++ b/src/pages/signUp/SignUpPage.tsx
@@ -9,7 +9,7 @@ import {
 import React, { useState } from "react";
 import cx from "classnames";
 import { useAuthentication } from "../../features/authentication";
-import Form, { Collection, useValidation } from "usetheform";
+import { Form, Collection, useValidation } from "usetheform";
 import {
   PasswordState,
   validateEmail,
@@ -111,7 +111,7 @@ export default function SignUpPage() {
             >
               Choose a password:
             </label>
-            <Collection name="passwords" object {...passwordsValidation}>
+            <Collection touched name="passwords" object {...passwordsValidation}>
               <TextInput
                 id="password"
                 className={cx("col-span-2")}

--- a/src/pages/utils/validation/PasswordState.ts
+++ b/src/pages/utils/validation/PasswordState.ts
@@ -1,0 +1,4 @@
+export default interface PasswordState {
+  password: string;
+  password2: string;
+}

--- a/src/pages/utils/validation/PasswordState.ts
+++ b/src/pages/utils/validation/PasswordState.ts
@@ -1,4 +1,4 @@
 export default interface PasswordState {
-  password: string;
-  password2: string;
+  password?: string;
+  password2?: string;
 }

--- a/src/pages/utils/validation/index.ts
+++ b/src/pages/utils/validation/index.ts
@@ -1,0 +1,6 @@
+export { default as validateEmail } from "./validateEmail";
+export { default as validateRequiredEmail } from "./validateRequiredEmail";
+export { default as validateRequiredPassword } from "./validateRequiredPassword";
+export { default as validateRequiredPasswords } from "./validateRequiredPasswords";
+export { default as validatePasswords } from "./validatePasswords";
+export type { default as PasswordState } from "./PasswordState";

--- a/src/pages/utils/validation/validateEmail.ts
+++ b/src/pages/utils/validation/validateEmail.ts
@@ -1,0 +1,5 @@
+export default function validateEmail(email: string) {
+  return !(email && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(email))
+    ? undefined
+    : "Invalid email address!";
+}

--- a/src/pages/utils/validation/validatePasswords.ts
+++ b/src/pages/utils/validation/validatePasswords.ts
@@ -1,0 +1,10 @@
+import PasswordState from "./PasswordState";
+
+export default function validatePasswords({
+  password,
+  password2,
+}: PasswordState) {
+  return password === password2
+    ? undefined
+    : "The passwords you entered do not match!";
+}

--- a/src/pages/utils/validation/validatePasswords.ts
+++ b/src/pages/utils/validation/validatePasswords.ts
@@ -3,7 +3,7 @@ import PasswordState from "./PasswordState";
 export default function validatePasswords({
   password,
   password2,
-}: PasswordState) {
+}: PasswordState = {}) {
   return password === password2
     ? undefined
     : "The passwords you entered do not match!";

--- a/src/pages/utils/validation/validateRequiredEmail.ts
+++ b/src/pages/utils/validation/validateRequiredEmail.ts
@@ -1,0 +1,5 @@
+export default function validateRequiredEmail(email: string) {
+  return email && email.trim() !== ""
+    ? undefined
+    : "Please enter your email address!";
+}

--- a/src/pages/utils/validation/validateRequiredPassword.ts
+++ b/src/pages/utils/validation/validateRequiredPassword.ts
@@ -1,4 +1,4 @@
-export default function validateRequiredPasswords(password: string) {
+export default function validateRequiredPassword(password: string) {
   return password && password.trim() !== ""
     ? undefined
     : "Please fill out the password field!";

--- a/src/pages/utils/validation/validateRequiredPassword.ts
+++ b/src/pages/utils/validation/validateRequiredPassword.ts
@@ -1,0 +1,5 @@
+export default function validateRequiredPasswords(password: string) {
+  return password && password.trim() !== ""
+    ? undefined
+    : "Please fill out the password field!";
+}

--- a/src/pages/utils/validation/validateRequiredPasswords.ts
+++ b/src/pages/utils/validation/validateRequiredPasswords.ts
@@ -9,5 +9,5 @@ export default function validateRequiredPasswords({
     password2 &&
     password2.trim() !== ""
     ? undefined
-    : "Please fill out the password fields!";
+    : "Please fill out both password fields!";
 }

--- a/src/pages/utils/validation/validateRequiredPasswords.ts
+++ b/src/pages/utils/validation/validateRequiredPasswords.ts
@@ -3,7 +3,7 @@ import PasswordState from "./PasswordState";
 export default function validateRequiredPasswords({
   password,
   password2,
-}: PasswordState) {
+}: PasswordState = {}) {
   return password &&
     password.trim() !== "" &&
     password2 &&

--- a/src/pages/utils/validation/validateRequiredPasswords.ts
+++ b/src/pages/utils/validation/validateRequiredPasswords.ts
@@ -1,0 +1,13 @@
+import PasswordState from "./PasswordState";
+
+export default function validateRequiredPasswords({
+  password,
+  password2,
+}: PasswordState) {
+  return password &&
+    password.trim() !== "" &&
+    password2 &&
+    password2.trim() !== ""
+    ? undefined
+    : "Please fill out the password fields!";
+}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="react-scripts" />
+declare module "usetheform" {
+  export const Input: any;
+  export const useValidation: any;
+  export const Collection: any;
+  declare const Form: any;
+  export default Form;
+}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -3,6 +3,5 @@ declare module "usetheform" {
   export const Input: any;
   export const useValidation: any;
   export const Collection: any;
-  declare const Form: any;
-  export default Form;
+  export const Form: any;
 }

--- a/src/ui/TextInput.tsx
+++ b/src/ui/TextInput.tsx
@@ -1,5 +1,6 @@
-import React, { MouseEvent, ChangeEvent, ForwardedRef, forwardRef } from "react";
+import React, { ChangeEvent, MouseEvent } from "react";
 import cx from "classnames";
+import { Input } from "usetheform";
 
 interface Props {
   id?: string;
@@ -8,25 +9,31 @@ interface Props {
   type?: "text" | "email" | "password";
   maxLength?: number;
   required?: boolean;
-  value?: string;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  validation?: any;
 }
 
-function TextInput(
-  { id, className, type, maxLength, required, value, onChange }: Props,
-  ref: ForwardedRef<HTMLInputElement>
-) {
+export default function TextInput({
+  id,
+  className,
+  type,
+  maxLength,
+  required,
+  onChange,
+  validation,
+}: Props) {
+  const validationProp = validation || {};
   return (
-    <input
+    <Input
       id={id}
+      name={id}
       className={cx(className, "shadow", "rounded")}
       type={type || "text"}
       maxLength={maxLength}
       required={required || false}
-      value={value}
       onChange={onChange}
-      ref={ref}
+      touched
+      {...validationProp}
     />
   );
 }
-export default forwardRef(TextInput);

--- a/src/ui/ValidationError.tsx
+++ b/src/ui/ValidationError.tsx
@@ -1,0 +1,16 @@
+import cx from "classnames";
+import React, { ReactNode } from "react";
+
+interface Props {
+  id?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+export default function ValidationError({ id, className, children }: Props) {
+  return (
+    <div id={id} className={cx(className, "font-semibold", "text-red")}>
+      {children}
+    </div>
+  );
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -5,3 +5,4 @@ export { default as MainHeadline } from "./MainHeadline";
 export { default as ModalWindow } from "./ModalWindow";
 export { default as Paragraph } from "./Paragraph";
 export { default as TextInput } from "./TextInput";
+export { default as ValidationError } from "./ValidationError";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,9 @@ module.exports = {
       black: {
         DEFAULT: "#000000",
       },
+      red: {
+        DEFAULT: "#cc3a32"
+      }
     },
   },
   variants: {


### PR DESCRIPTION
Now using Antonio's [usetheform](https://iusehooks.github.io/usetheform/) library for form handling on sign up and log in pages.

![image](https://user-images.githubusercontent.com/1639313/100637578-55288680-3333-11eb-849c-4b2f7b91f8f4.png)

Some feedback on *usetheform* I've gathered while working with it:

- There are no TypeScript definitions available, so I had to resort to writing my own
- I found it confusing that the _Input_ component is imported using _import {Input} from 'usetheform'_, while the Form component is the default export, thus imported using _import Form from 'usetheform'_
- It seems a bit redundant to pass an _initalState_ prop to the Form component and at the same time pass _updateFormState_ as callback _onInit_ prop
- At first, I passed the value from the form state as value prop of my input components, like this: _<Input name="email" value={formState.email} />_ – this did not work, of course; I did not know that _usetheform_ automatically uses the value from the form state, using the name prop – does it even make sense supporting a value prop at all?
- It would be cool if I could pass refs to the _Form_ and _Input_ components to have control over the form element's DOM nodes; I like to use the browser's built in validation features and add my own validation messages using [setCustomValidity](https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity), but this only works if I have access to the DOM
- The combination of the _touched_ prop and the validation status only works if the validations are directly on an Input component; if the validations are on a _Collection_ component around _Input_ components with _touched_, this does not have any effect; I would expect the validation of the collection to trigger when of the nested inputs is blurred